### PR TITLE
fix: Reload client side tests 2

### DIFF
--- a/package/server.js
+++ b/package/server.js
@@ -200,10 +200,10 @@ export { start };
 
 onMessage('client-refresh', (options) => {
   console.log('CLIENT TESTS RESTARTING (client-refresh)', options === undefined ? '' : options);
-  clientTests()
+  clientTests();
 });
 
 onMessage('webapp-reload-client', (options) => {
   console.log('CLIENT TESTS RESTARTING (webapp-reload-client)', options === undefined ? '' : options);
-  clientTests()
+  clientTests();
 });


### PR DESCRIPTION
this PR fix the lint errors of this PR https://github.com/Meteor-Community-Packages/meteor-mocha/pull/106

After my use (8+ months) as a local package with this PR https://github.com/Meteor-Community-Packages/meteor-mocha/pull/106 I think it is good to merge as-is.

Client-side tests are reloaded correctly with this PR  95% time. Without this PR client-side tests are not reloaded at all.
Rarely (5%) Chrome would crash when watching client tests, and mocha would need to be restarted.