### PR TITLE
Ensure compatibility with the new meteor-coverage version

### DIFF
--- a/package/package.js
+++ b/package/package.js
@@ -3,7 +3,7 @@ Package.describe({
   summary: 'Run Meteor package or app tests with Mocha',
   git: 'https://github.com/meteortesting/meteor-mocha.git',
   documentation: '../README.md',
-  version: '2.0.2',
+  version: '2.0.3',
   testOnly: true,
 });
 
@@ -15,7 +15,7 @@ Package.onUse(function onUse(api) {
 
   api.use(['meteortesting:browser-tests@1.3.2', 'http@1.0.0 || 2.0.0'], 'server');
   api.use('browser-policy@1.0.0', 'server', { weak: true });
-  api.use('lmieulet:meteor-coverage@1.1.4 || 2.0.1 || 3.0.0', 'client', { weak: true });
+  api.use('lmieulet:meteor-coverage@1.1.4 || 2.0.1 || 3.0.0 || 4.0.0', 'client', { weak: true });
 
   api.mainModule('client.js', 'client');
   api.mainModule('server.js', 'server');


### PR DESCRIPTION
This PR is needed to ensure meteor projects that use the new 2.3.x version to use testing capabilities like meteor-coverage. This package got updated to ensure compatibility with [2.3.x](https://github.com/serut/meteor-coverage/commit/7cbcda6c55ea3d5887c8567defb17c01ad4e15d0#diff-b7910dbf1a3c6dd04a6b8ad8e8ae6929b9ec2de4006bccdec22ac2c55fe2e3dc) on 4.0.0.