### PR TITLE
Fix/coverage integration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,10 @@
     "max-len": 0,
     "no-console": 0,
     "no-plusplus": 0,
-    "object-curly-newline": 0
+    "object-curly-newline": 0,
+    "template-curly-spacing" : "off",
+    "indent": ["error", 2, {
+      "ignoredNodes": ["TemplateLiteral"]
+    }]
   }
 }

--- a/package/package.js
+++ b/package/package.js
@@ -3,7 +3,7 @@ Package.describe({
   summary: 'Run Meteor package or app tests with Mocha',
   git: 'https://github.com/meteortesting/meteor-mocha.git',
   documentation: '../README.md',
-  version: '3.0.0',
+  version: '3.2.0',
   testOnly: true,
 });
 
@@ -19,7 +19,7 @@ Package.onUse(function onUse(api) {
     'http@1.0.0 || 2.0.0'
   ], 'server');
   api.use('browser-policy', 'server', { weak: true });
-  api.use('lmieulet:meteor-coverage@1.1.4 || 2.0.1 || 3.0.0 || 4.1.0', 'client', { weak: true });
+  api.use('lmieulet:meteor-coverage@1.1.4 || 2.0.1 || 3.0.0 || 4.3.0', 'client', { weak: true });
 
   api.mainModule('client.js', 'client');
   api.mainModule('server.js', 'server');

--- a/package/package.js
+++ b/package/package.js
@@ -19,7 +19,7 @@ Package.onUse(function onUse(api) {
     'http@1.0.0 || 2.0.0'
   ], 'server');
   api.use('browser-policy', 'server', { weak: true });
-  api.use('lmieulet:meteor-coverage@1.1.4 || 2.0.1 || 3.0.0 || 4.3.0', 'client', { weak: true });
+  api.use('lmieulet:meteor-coverage@1.1.4 || 2.0.1 || 3.0.0 || 4.3.0 || 5.0.0', 'client', { weak: true });
 
   api.mainModule('client.js', 'client');
   api.mainModule('server.js', 'server');

--- a/package/package.js
+++ b/package/package.js
@@ -19,7 +19,7 @@ Package.onUse(function onUse(api) {
     'http@1.0.0 || 2.0.0'
   ], 'server');
   api.use('browser-policy', 'server', { weak: true });
-  api.use('lmieulet:meteor-coverage@1.1.4 || 2.0.1 || 3.0.0 || 4.3.0 || 5.0.0', 'client', { weak: true });
+  api.use('lmieulet:meteor-coverage@1.1.4 || 2.0.1 || 3.0.0 || 4.0.0 || 5.0.0', 'client', { weak: true });
 
   api.mainModule('client.js', 'client');
   api.mainModule('server.js', 'server');

--- a/package/package.js
+++ b/package/package.js
@@ -16,7 +16,7 @@ Package.onUse(function onUse(api) {
 
   api.use([
     'meteortesting:browser-tests@1.7.0',
-    'http@1.0.0 || 2.0.0'
+    'fetch'
   ], 'server');
   api.use('browser-policy', 'server', { weak: true });
   api.use('lmieulet:meteor-coverage@1.1.4 || 2.0.1 || 3.0.0 || 4.0.0 || 5.0.0', 'client', { weak: true });

--- a/package/server.handleCoverage.js
+++ b/package/server.handleCoverage.js
@@ -17,8 +17,8 @@ const request = async ({ url, message }) => {
     throw new Error(`${message} ${error.message}`);
   }
 
-  if (response?.statusCode !== 200) {
-    throw new Error(`${message} ${response?.statusCode} ${data}`);
+  if (response?.status !== 200) {
+    throw new Error(`${message} ${response?.status} ${data}`);
   }
 
   return data;

--- a/package/server.handleCoverage.js
+++ b/package/server.handleCoverage.js
@@ -1,5 +1,29 @@
 import { fetch } from 'meteor/fetch';
 
+/**
+ * Makes a standardized HTTP GET request to the server.
+ * @private
+ * @param url {string} relative path to the server endpoint
+ * @param message {string} message to be added, in case an error is thrown
+ * @return {Promise<any>}
+ */
+const request = async ({ url, message }) => {
+  let response;
+  let data;
+  try {
+    response = await fetch(Meteor.absoluteUrl(url));
+    data = await response.json();
+  } catch (error) {
+    throw new Error(`${message} ${error.message}`);
+  }
+
+  if (response?.statusCode !== 200) {
+    throw new Error(`${message} ${response?.statusCode} ${data}`);
+  }
+
+  return data;
+};
+
 export default (coverageOptions) => {
   let promise = Promise.resolve(true);
 
@@ -16,25 +40,24 @@ export default (coverageOptions) => {
       cLog('- In coverage');
       return request({
         url: 'coverage/import',
-        message: 'Failed to import coverage file.'
-      })
+        message: 'Failed to import coverage file.',
+      });
     };
 
     const exportReport = async (fileType, reportType) => {
       cLog(`- Out ${fileType}`);
-
       return request({
         url: `/coverage/export/${fileType}`,
-        message: `Failed to save ${fileType} ${reportType}.`
-      })
+        message: `Failed to save ${fileType} ${reportType}.`,
+      });
     };
 
     const exportRemap = async () => {
       cLog('- Out remap');
       return request({
         url: '/coverage/export/remap',
-        message: '`Failed to remap your coverage.'
-      })
+        message: '`Failed to remap your coverage.',
+      });
     };
 
     if (coverageOptions.in.coverage) {
@@ -74,28 +97,3 @@ export default (coverageOptions) => {
 
   return promise;
 };
-
-/**
- * Makes a standardized HTTP GET request to the server.
- * @private
- * @param url {string} relative path to the server endpoint
- * @param message {string} message to be added, in case an error is thrown
- * @return {Promise<any>}
- */
-const request = async ({ url, message }) => {
-  let response
-  let data
-  try {
-    response = await fetch(Meteor.absoluteUrl(url));
-    data = await response.json();
-  } catch (error) {
-    throw new Error(`${message} ${error.message}`);
-  }
-
-
-  if (response?.statusCode !== 200) {
-    throw new Error(`${message} ${response?.statusCode} ${data}`);
-  }
-
-  return data
-}

--- a/package/server.handleCoverage.js
+++ b/package/server.handleCoverage.js
@@ -1,4 +1,4 @@
-import { HTTP } from 'meteor/http';
+import { fetch } from 'meteor/fetch';
 
 export default (coverageOptions) => {
   let promise = Promise.resolve(true);
@@ -12,57 +12,30 @@ export default (coverageOptions) => {
 
     cLog('Export code coverage');
 
-    const importCoverageDump = () => new Promise((resolve, reject) => {
+    const importCoverageDump = () => async () => {
       cLog('- In coverage');
-      HTTP.get(Meteor.absoluteUrl('coverage/import'), (error, response) => {
-        if (error) {
-          reject(new Error(`Failed to import coverage file. ${error.message}`));
-          return;
-        }
+      return request({
+        url: 'coverage/import',
+        message: 'Failed to import coverage file.'
+      })
+    };
 
-        const { statusCode } = response;
-
-        if (statusCode !== 200) {
-          reject(new Error(`Failed to import coverage file. ${statusCode} ${response.data}`));
-        }
-        resolve();
-      });
-    });
-
-    const exportReport = (fileType, reportType) => new Promise((resolve, reject) => {
+    const exportReport = async (fileType, reportType) => {
       cLog(`- Out ${fileType}`);
-      const url = Meteor.absoluteUrl(`/coverage/export/${fileType}`);
-      HTTP.get(url, (error, response) => {
-        if (error) {
-          reject(new Error(`Failed to save ${fileType} ${reportType}. ${error.message}`));
-          return;
-        }
 
-        const { statusCode } = response;
+      return request({
+        url: `/coverage/export/${fileType}`,
+        message: `Failed to save ${fileType} ${reportType}.`
+      })
+    };
 
-        if (statusCode !== 200) {
-          reject(new Error(`Failed to save ${fileType} ${reportType}. ${statusCode} ${response.data}`));
-        }
-        resolve();
-      });
-    });
-
-    const exportRemap = () => new Promise((resolve, reject) => {
+    const exportRemap = async () => {
       cLog('- Out remap');
-      HTTP.get(Meteor.absoluteUrl('/coverage/export/remap'), (error, response) => {
-        if (error) {
-          reject(new Error(`Failed to remap your coverage. ${error.message}`));
-          return;
-        }
-
-        const { statusCode } = response;
-
-        if (statusCode !== 200) {
-          reject(new Error(`Failed to remap your coverage. ${statusCode} ${response.data}`));
-        }
-        resolve();
-      });
-    });
+      return request({
+        url: '/coverage/export/remap',
+        message: '`Failed to remap your coverage.'
+      })
+    };
 
     if (coverageOptions.in.coverage) {
       promise = promise.then(() => importCoverageDump());
@@ -101,3 +74,28 @@ export default (coverageOptions) => {
 
   return promise;
 };
+
+/**
+ * Makes a standardized HTTP GET request to the server.
+ * @private
+ * @param url {string} relative path to the server endpoint
+ * @param message {string} message to be added, in case an error is thrown
+ * @return {Promise<any>}
+ */
+const request = async ({ url, message }) => {
+  let response
+  let data
+  try {
+    response = await fetch(Meteor.absoluteUrl(url));
+    data = await response.json();
+  } catch (error) {
+    throw new Error(`${message} ${error.message}`);
+  }
+
+
+  if (response?.statusCode !== 200) {
+    throw new Error(`${message} ${response?.statusCode} ${data}`);
+  }
+
+  return data
+}

--- a/package/server.handleCoverage.js
+++ b/package/server.handleCoverage.js
@@ -16,14 +16,14 @@ export default (coverageOptions) => {
       cLog('- In coverage');
       HTTP.get(Meteor.absoluteUrl('coverage/import'), (error, response) => {
         if (error) {
-          reject(new Error('Failed to import coverage file'));
+          reject(new Error(`Failed to import coverage file. ${error.message}`));
           return;
         }
 
         const { statusCode } = response;
 
         if (statusCode !== 200) {
-          reject(new Error('Failed to import coverage file'));
+          reject(new Error(`Failed to import coverage file. ${statusCode} ${response.data}`));
         }
         resolve();
       });
@@ -34,14 +34,14 @@ export default (coverageOptions) => {
       const url = Meteor.absoluteUrl(`/coverage/export/${fileType}`);
       HTTP.get(url, (error, response) => {
         if (error) {
-          reject(new Error(`Failed to save ${fileType} ${reportType}`));
+          reject(new Error(`Failed to save ${fileType} ${reportType}. ${error.message}`));
           return;
         }
 
         const { statusCode } = response;
 
         if (statusCode !== 200) {
-          reject(new Error(`Failed to save ${fileType} ${reportType}`));
+          reject(new Error(`Failed to save ${fileType} ${reportType}. ${statusCode} ${response.data}`));
         }
         resolve();
       });
@@ -51,14 +51,14 @@ export default (coverageOptions) => {
       cLog('- Out remap');
       HTTP.get(Meteor.absoluteUrl('/coverage/export/remap'), (error, response) => {
         if (error) {
-          reject(new Error('Failed to remap your coverage'));
+          reject(new Error(`Failed to remap your coverage. ${error.message}`));
           return;
         }
 
         const { statusCode } = response;
 
         if (statusCode !== 200) {
-          reject(new Error('Failed to remap your coverage'));
+          reject(new Error(`Failed to remap your coverage. ${statusCode} ${response.data}`));
         }
         resolve();
       });

--- a/tests/dummy_app/.meteor/versions
+++ b/tests/dummy_app/.meteor/versions
@@ -29,12 +29,16 @@ geojson-utils@1.0.12
 hot-code-push@1.0.5
 html-tools@2.0.0-alpha300.17
 htmljs@2.0.0-alpha300.17
+http@1.0.1
 id-map@1.2.0
 inter-process-messaging@0.1.2
 launch-screen@2.0.1
 logging@1.3.5
 meteor@2.0.0
 meteor-base@1.5.2
+meteortesting:browser-tests@1.7.0
+meteortesting:mocha@3.2.0
+meteortesting:mocha-core@8.2.0
 minifier-css@2.0.0
 minifier-js@3.0.0
 minimongo@2.0.0


### PR DESCRIPTION
Improves coverage error messages and bumps the version to 3.2.0

> Important

due to a past wrong publishing versions during migration times we get actually `3.0.3` being resolved as the latest when using `meteortesting:mocha@3.0.0` in packages. However, this version is **older** than `3.0.0`. The best fix is to bump to `3.2.0` and release it so it's the latest resolved version.