### PR TITLE
Bugfix/xunit browser output

### DIFF
--- a/package/client.js
+++ b/package/client.js
@@ -41,7 +41,7 @@ function runTests() {
 
   if (!runnerOptions.runClient) return;
 
-  const { clientReporter, grep, invert, reporter } = mochaOptions || {};
+  const { clientReporter, grep, invert } = mochaOptions || {};
   if (grep) mocha.grep(grep);
   if (invert) mocha.invert(invert);
 
@@ -52,7 +52,7 @@ function runTests() {
     mocha.color(true);
   }
 
-  let currentReporter = clientReporter || reporter;
+  let currentReporter = clientReporter;
   if (!currentReporter) {
     currentReporter = runnerOptions.browserDriver ? 'spec' : 'html';
   }

--- a/package/runtimeArgs.js
+++ b/package/runtimeArgs.js
@@ -30,9 +30,8 @@ export default function setArgs() {
     mochaOptions: {
       grep: MOCHA_GREP || false,
       invert: !!MOCHA_INVERT,
-      reporter: MOCHA_REPORTER,
-      serverReporter: SERVER_TEST_REPORTER || XUNIT_FILE, // XUNIT_FILE is left in here for compatibility to older versions
-      clientReporter: CLIENT_TEST_REPORTER,
+      serverReporter: SERVER_TEST_REPORTER || MOCHA_REPORTER || XUNIT_FILE, // XUNIT_FILE is left in here for compatibility to older versions
+      clientReporter: CLIENT_TEST_REPORTER || MOCHA_REPORTER,
       serverOutput: SERVER_MOCHA_OUTPUT,
       clientOutput: CLIENT_MOCHA_OUTPUT,
     },

--- a/package/server.js
+++ b/package/server.js
@@ -13,7 +13,6 @@ let runnerOptions;
 let coverageOptions;
 let grep;
 let invert;
-let reporter;
 let clientReporter;
 let serverReporter;
 let serverOutput;
@@ -125,7 +124,7 @@ function serverTests(cb) {
   // We need to set the reporter when the tests actually run to ensure no conflicts with
   // other test driver packages that may be added to the app but are not actually being
   // used on this run.
-  mochaInstance.reporter(serverReporter || reporter || 'spec', {
+  mochaInstance.reporter(serverReporter || 'spec', {
     output: serverOutput,
   });
 
@@ -212,7 +211,6 @@ function start() {
   mochaOptions = args.mochaOptions;
   grep = mochaOptions.grep;
   invert = mochaOptions.invert;
-  reporter = mochaOptions.reporter;
   clientReporter = mochaOptions.clientReporter;
   serverReporter = mochaOptions.serverReporter;
   serverOutput = mochaOptions.serverOutput;

--- a/package/server.js
+++ b/package/server.js
@@ -14,6 +14,7 @@ let coverageOptions;
 let grep;
 let invert;
 let reporter;
+let clientReporter;
 let serverReporter;
 let serverOutput;
 let clientOutput;
@@ -39,7 +40,7 @@ const clientLines = [];
 function clientLogBuffer(line) {
   if (serverTestsDone) {
     // printing and removing the extra new-line character. The first was added by the client log, the second here.
-    console.log(line.replace(/\n$/, ''));
+    console.log(line);
   } else {
     clientLines.push(line);
   }
@@ -73,10 +74,7 @@ function exitIfDone(type, failures) {
   } else {
     serverFailures = failures;
     serverTestsDone = true;
-    clientLines.forEach((line) => {
-      // printing and removing the extra new-line character. The first was added by the client log, the second here.
-      console.log(line.replace(/\n$/, ''));
-    });
+    clientLines.forEach(console.log);
   }
 
   if (callCount === 2) {
@@ -144,6 +142,26 @@ function serverTests(cb) {
   });
 }
 
+function isXunitLine(line) {
+  return line.trimLeft().startsWith('<');
+}
+
+function browserOutput(data) {
+  // Take full control over line breaks to prevent duplication
+  const line = data.toString().replace(/\n$/, '');
+  if (clientOutput) {
+    // Edge case: with XUNIT reporter write only XML to the output file
+    if (clientReporter !== 'xunit' || isXunitLine(line)) {
+      fs.appendFileSync(clientOutput, `${line}\n`);
+    } else {
+      // Output non-XML lines to console (XUNIT reporter only) 
+      clientLogBuffer(line);
+    }
+  } else {
+    clientLogBuffer(line);
+  }
+}
+
 function clientTests() {
   if (clientTestsRunning) {
     console.log('CLIENT TESTS ALREADY RUNNING');
@@ -169,27 +187,9 @@ function clientTests() {
   clientTestsRunning = true;
 
   startBrowser({
-    stdout(data) {
-      if (clientOutput) {
-        fs.appendFileSync(clientOutput, data.toString());
-      } else {
-        clientLogBuffer(data.toString());
-      }
-    },
-    writebuffer(data) {
-      if (clientOutput) {
-        fs.appendFileSync(clientOutput, data.toString());
-      } else {
-        clientLogBuffer(data.toString());
-      }
-    },
-    stderr(data) {
-      if (clientOutput) {
-        fs.appendFileSync(clientOutput, data.toString());
-      } else {
-        clientLogBuffer(data.toString());
-      }
-    },
+    stdout: browserOutput,
+    writebuffer: browserOutput,
+    stderr: browserOutput,
     done(failureCount) {
       clientTestsRunning = false;
       if (typeof failureCount !== 'number') {
@@ -213,6 +213,7 @@ function start() {
   grep = mochaOptions.grep;
   invert = mochaOptions.invert;
   reporter = mochaOptions.reporter;
+  clientReporter = mochaOptions.clientReporter;
   serverReporter = mochaOptions.serverReporter;
   serverOutput = mochaOptions.serverOutput;
   clientOutput = mochaOptions.clientOutput;


### PR DESCRIPTION
This is a fix for the XUNIT reporter output from the client. I was experiencing issues with this when running client tests in headless mode via Puppeteer. 

Here's a reproduction repository: https://github.com/imajus/meteor-browser-tests-issue/

Expected to get XML in `test-results/client.xml` but getting the following contents:

```
In the test groupIn the test case<testsuite name="Mocha Tests" tests="1" failures="0" errors="1" skipped="0" timestamp="Fri, 20 Sep 2024 05:34:25 GMT" time="0.003">
<testcase classname="Example" name="test" time="0.001"><failure>undefined undefined undefined
AssertionError: undefined undefined undefined
    at Context.&#x3C;anonymous&#x3E; (app/app.js?hash=818e846856c24f4b042929071138d0f3cfb8a773:20:12)
    at callFn (packages/meteortesting_mocha-core.js?hash=dd1ee602c0eabe4198d6106e7f5734b6963d105c:13223:23)
    at Test$4.Runnable$3.run (packages/meteortesting_mocha-core.js?hash=dd1ee602c0eabe4198d6106e7f5734b6963d105c:13211:7)
    at Runner.runTest (packages/meteortesting_mocha-core.js?hash=dd1ee602c0eabe4198d6106e7f5734b6963d105c:14756:12)
    at http://localhost:3000/packages/meteortesting_mocha-core.js?hash=dd1ee602c0eabe4198d6106e7f5734b6963d105c:14879:14
    at next (packages/meteortesting_mocha-core.js?hash=dd1ee602c0eabe4198d6106e7f5734b6963d105c:14671:16)
    at http://localhost:3000/packages/meteortesting_mocha-core.js?hash=dd1ee602c0eabe4198d6106e7f5734b6963d105c:14681:9
    at next (packages/meteortesting_mocha-core.js?hash=dd1ee602c0eabe4198d6106e7f5734b6963d105c:14564:16)
    at http://localhost:3000/packages/meteortesting_mocha-core.js?hash=dd1ee602c0eabe4198d6106e7f5734b6963d105c:14649:7
    at timeslice (packages/meteortesting_mocha-core.js?hash=dd1ee602c0eabe4198d6106e7f5734b6963d105c:20603:29)</failure></testcase>
</testsuite>
```

As part of this PR there's also a refactoring which makes is easier to handle the `MOCHA_REPORTER` environment variable value in the source code.