### PR TITLE
feat: attribute suites and tests to the file they were declared in

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,26 @@ To write the tests to a file, set `SERVER_MOCHA_OUTPUT` and `CLIENT_MOCHA_OUTPUT
 $ MOCHA_REPORTER=xunit SERVER_MOCHA_OUTPUT=$PWD/unit_server.xml CLIENT_MOCHA_OUTPUT=$PWD/unit_client.xml meteor test --once --driver-package meteortesting:mocha
 ```
 
+### Test file names in reporter output
+
+Server-side suites and tests carry the app-relative path of the file they were
+declared in, e.g. `server/user.tests.js`, so reporters that report it do too:
+
+```xml
+<testcase classname="user methods" name="creates a user" file="server/user.tests.js" time="0.012"/>
+```
+
+This makes the `xunit` output usable with CI test splitting that matches timing
+data by file name. It requires `meteortesting:mocha-core@9.0.0` or later, whose
+mocha version writes the `file` attribute.
+
+Suites created by a helper are attributed to the file that called the helper,
+not to the file the helper lives in. In `meteor test-packages` runs the path is
+the one inside the package, e.g. `packages/my-package/user.tests.js`.
+
+Client-side suites are not attributed, because browser stack traces are not
+mapped back to the app's source files.
+
 ### Run with a different server reporter
 
 The default Mocha reporter for server tests is the "spec" reporter. You can set the `SERVER_TEST_REPORTER` environment variable to change it.

--- a/package/package.js
+++ b/package/package.js
@@ -9,7 +9,7 @@ Package.describe({
 
 Package.onUse(function onUse(api) {
   api.versionsFrom(['2.8.0', '3.0']);
-  api.use(['meteortesting:mocha-core@8.2.0', 'ecmascript']);
+  api.use(['meteortesting:mocha-core@8.2.0 || 9.0.0', 'ecmascript']);
 
   api.use(['meteortesting:browser-tests@1.8.0', 'fetch'], 'server');
   api.use('browser-policy', 'server', { weak: true });

--- a/package/server.fileAttribution.js
+++ b/package/server.fileAttribution.js
@@ -1,0 +1,209 @@
+/**
+ * Records the source file each suite and test was declared in.
+ *
+ * Mocha takes `Suite.file` and `Test.file` from the file name it passes to the
+ * `pre-require` event while loading a spec. Meteor loads test files through its
+ * own module system, so `meteortesting:mocha-core` emits that event once with
+ * no file name and every suite, test and hook ends up with `file: undefined` —
+ * which is what reporters that report the file (xunit, json) then print.
+ *
+ * The server bundle installs source-map-support and rewrites frames to paths
+ * relative to the app root, so the declaring file can be read back out of a
+ * stack trace taken while the suite is being defined.
+ */
+
+const SUITE_GLOBALS = ['describe', 'context', 'xdescribe', 'xcontext'];
+const TEST_GLOBALS = ['it', 'specify', 'xit', 'xspecify'];
+
+const POSITION = /:\d+:\d+$/;
+const WINDOWS_ABSOLUTE = /^[A-Za-z]:[\\/]/;
+const PACKAGE_PREFIX = 'packages/';
+// Package frames that are always a step on the way to a suite, never its
+// source: this driver, and the runtimes that load a module in the first place.
+const PLUMBING = [
+  'packages/meteortesting:mocha',
+  'packages/modules',
+  'packages/core-runtime',
+  'packages/babel-runtime',
+  'packages/ecmascript-runtime',
+  'packages/dynamic-import',
+  'packages/promise',
+];
+const MAX_FRAMES = 30;
+const HOOKS = ['_beforeAll', '_beforeEach', '_afterEach', '_afterAll'];
+
+const APP = 'app';
+const PACKAGE = 'package';
+const OTHER = 'other';
+
+const wrappers = new WeakMap();
+
+// Only source-mapped Meteor modules appear as paths relative to the app root or
+// to "packages/". Mocha and its dependencies are resolved from the isopack's
+// node_modules and the bundle itself is read from a build directory, so both
+// show up as absolute paths; Node internals have their own prefixes.
+function frame(line) {
+  const call = line.trim();
+  if (!call.startsWith('at ')) {
+    return { kind: OTHER };
+  }
+
+  // "at name (location)" for a named frame, "at location" for the rest.
+  const frameSource = call.slice(3);
+  const source = frameSource.endsWith(')')
+    ? frameSource.slice(frameSource.lastIndexOf('(') + 1, -1)
+    : frameSource;
+  const location = source.replace(POSITION, '');
+  if (
+    !location ||
+    location.startsWith('/') ||
+    location.startsWith('<') ||
+    location.startsWith('node:') ||
+    location.startsWith('internal/') ||
+    location.includes('node_modules/') ||
+    location.includes('://') ||
+    WINDOWS_ABSOLUTE.test(location)
+  ) {
+    return { kind: OTHER };
+  }
+
+  return location.startsWith(PACKAGE_PREFIX)
+    ? { kind: PACKAGE, location }
+    : { kind: APP, location };
+}
+
+// Reading the stack runs it through source-map-support. Nothing here is worth
+// failing a test run over, so a surprise leaves the suite unattributed instead.
+function callerFrames() {
+  const limit = Error.stackTraceLimit;
+  try {
+    Error.stackTraceLimit = MAX_FRAMES;
+    const probe = {};
+    Error.captureStackTrace(probe, callerFrames);
+    const { stack } = probe;
+
+    return stack ? stack.split('\n').slice(1).map(frame) : [];
+  } catch {
+    return [];
+  } finally {
+    Error.stackTraceLimit = limit;
+  }
+}
+
+function declaringFile() {
+  const frames = callerFrames();
+
+  // The outermost frame of the first run of app frames is the file Meteor
+  // loaded; the frames below it belong to helpers that called `describe` on
+  // its behalf.
+  let file;
+  for (const { kind, location } of frames) {
+    if (kind === APP) {
+      file = location;
+    } else if (file) {
+      break;
+    }
+  }
+  if (file) {
+    return file;
+  }
+
+  // `meteor test-packages` runs suites declared inside a package, where the
+  // innermost frame that is not plumbing is the file.
+  const declaration = frames.find(
+    (candidate) =>
+      candidate.kind === PACKAGE &&
+      !PLUMBING.some((prefix) => candidate.location.startsWith(prefix)),
+  );
+  return declaration?.location;
+}
+
+function stamp(suite, file) {
+  if (!suite.file) {
+    suite.file = file;
+  }
+
+  for (const key of ['tests', ...HOOKS]) {
+    for (const runnable of suite[key] ?? []) {
+      if (!runnable.file) {
+        runnable.file = file;
+      }
+    }
+  }
+
+  for (const child of suite.suites ?? []) {
+    stamp(child, file);
+  }
+}
+
+// `describe.skip` is the same function as `xdescribe`, so wrappers are cached
+// to keep those identities intact.
+function wrapSuiteFunction(original) {
+  if (wrappers.has(original)) {
+    return wrappers.get(original);
+  }
+
+  const wrapper = function wrappedSuite(...args) {
+    const suite = original.apply(this, args);
+    const file = declaringFile();
+    if (file && suite && Array.isArray(suite.tests)) {
+      stamp(suite, file);
+    }
+    return suite;
+  };
+  wrappers.set(original, wrapper);
+
+  for (const key of Object.keys(original)) {
+    wrapper[key] =
+      typeof original[key] === 'function'
+        ? wrapSuiteFunction(original[key])
+        : original[key];
+  }
+
+  return wrapper;
+}
+
+// Tests declared inside a suite are stamped by the wrapper above once the
+// suite body has run, which also covers tests added later from a hook. Only
+// tests at the root have no suite to inherit from.
+function wrapTestFunction(original) {
+  if (wrappers.has(original)) {
+    return wrappers.get(original);
+  }
+
+  const wrapper = function wrappedTest(...args) {
+    const test = original.apply(this, args);
+    if (test && !test.file && test.parent) {
+      if (test.parent.file) {
+        test.file = test.parent.file;
+      } else if (test.parent.root) {
+        test.file = declaringFile();
+      }
+    }
+    return test;
+  };
+  wrappers.set(original, wrapper);
+
+  for (const key of Object.keys(original)) {
+    wrapper[key] =
+      typeof original[key] === 'function'
+        ? wrapTestFunction(original[key])
+        : original[key];
+  }
+
+  return wrapper;
+}
+
+export default function attributeTestFiles(scope = global) {
+  for (const name of SUITE_GLOBALS) {
+    if (typeof scope[name] === 'function') {
+      scope[name] = wrapSuiteFunction(scope[name]);
+    }
+  }
+
+  for (const name of TEST_GLOBALS) {
+    if (typeof scope[name] === 'function') {
+      scope[name] = wrapTestFunction(scope[name]);
+    }
+  }
+}

--- a/package/server.js
+++ b/package/server.js
@@ -6,7 +6,12 @@ import { onMessage } from 'meteor/inter-process-messaging';
 import fs from 'node:fs';
 
 import setArgs from './runtimeArgs';
+import attributeTestFiles from './server.fileAttribution';
 import handleCoverage from './server.handleCoverage';
+
+// Must run before the app's test files are loaded, so that the suites they
+// declare are attributed to the file they were declared in.
+attributeTestFiles();
 
 let mochaOptions;
 let runnerOptions;

--- a/tests/dummy_app/imports/declareSuite.js
+++ b/tests/dummy_app/imports/declareSuite.js
@@ -1,0 +1,7 @@
+/* eslint-env mocha */
+
+// Stands in for the `conditionalDescribe`-style helpers apps write: the suite
+// is created here, but belongs to the test file that called this.
+export function declareSuite(name, fn) {
+  return describe(name, fn);
+}

--- a/tests/dummy_app/server/file-attribution.tests.js
+++ b/tests/dummy_app/server/file-attribution.tests.js
@@ -1,0 +1,33 @@
+/* eslint-env mocha */
+import assert from 'node:assert';
+import { declareSuite } from '../imports/declareSuite';
+
+const FILE = 'server/file-attribution.tests.js';
+
+const suite = describe('file attribution', function () {
+  const test = it('attributes a test to the file it was declared in', function () {
+    assert.strictEqual(test.file, FILE);
+  });
+
+  it('attributes a suite to the file it was declared in', function () {
+    assert.strictEqual(suite.file, FILE);
+  });
+
+  it('attributes the hooks of a suite', function () {
+    assert.strictEqual(suite._beforeAll[0].file, FILE);
+  });
+
+  before(function () {});
+
+  describe('nested suite', function () {
+    const nested = it('attributes a nested test', function () {
+      assert.strictEqual(nested.file, FILE);
+    });
+  });
+});
+
+const viaHelper = declareSuite('file attribution via a helper', function () {
+  it('attributes the suite to the file that called the helper', function () {
+    assert.strictEqual(viaHelper.file, FILE);
+  });
+});


### PR DESCRIPTION
## What

Suites, tests and hooks now carry the path of the file they were declared in, so
reporters that report the file (`xunit`, `json`) report something useful:

```xml
<testcase classname="user methods" name="creates a user" file="server/user.tests.js" time="0.012"/>
```

## Why

Mocha reads `Suite.file` and `Test.file` from the file name passed to the
`pre-require` event while it loads a spec. Meteor loads test files through its
own module system, so `meteortesting:mocha-core` emits that event once with no
file name (`mocha.suite.emit('pre-require', mochaExports, undefined, mocha)`),
and mocha's bdd interface closes over that `undefined` for every suite and test.

The practical cost is CI test splitting: `circleci tests split --split-by=timings
--timings-type=filename` and its equivalents match timing data by file name, so
without the attribute a Meteor app has to reconstruct it from the XML afterwards
(we do this today with a script that maps top-level `describe` names back to
files, which needs those names to be unique).

## How

`server.fileAttribution.js` wraps the suite and test globals mocha-core installs
and takes a stack trace while the suite is being defined. The server bundle
installs `source-map-support` and Meteor's `boot.js` strips the
`meteor://<...>app/` prefix from frames, so app modules appear as paths relative
to the app root (`server/user.tests.js`) and package modules as
`packages/my-package/user.tests.js` — while mocha itself, the bundle and Node
internals appear as absolute paths and are ignored.

Of the resulting frames:

- the outermost frame of the first run of app frames wins, so a suite created by
  a `conditionalDescribe`-style helper is attributed to the file that called the
  helper — the file Meteor loaded, and the one CI splits on;
- with no app frame in the stack (a `meteor test-packages` run), the innermost
  frame that is not this driver or a Meteor runtime is used;
- suites keep the file they already have, so nothing is overwritten.

Tests inside a suite are stamped when the suite body has finished, which also
covers tests added later from a hook; only root-level tests take a trace of
their own.

## Scope

- Server only. Browser stack traces are not mapped back to source, so client
  suites are left unattributed rather than pointing at the bundle.
- The `file` attribute reaches the `xunit` output only with
  `meteortesting:mocha-core@9.0.0` (companion PR
  "feat!: update mocha to 11.8.0" in Meteor-Community-Packages/meteor-mocha-core),
  whose mocha is new enough to write it — mocha added it in 10.4.0, and core
  currently bundles 10.2.0. The constraint here is widened to `8.2.0 || 9.0.0`
  so either resolves.
- Note for whoever merges the core bump: with mocha >= 10.4.0 an unattributed
  test is written as `file="undefined"`, since the reporter stringifies whatever
  it gets. That is what this change removes for app and package runs.

## Testing

Two regression tests in the dummy app assert the attribution from inside the
run — one file declaring suites directly, one through a helper in `imports/`.
Verified on Meteor 3.4:

- with the released `mocha-core@8.2.0`: 8 passing (the assertions hold; the XML
  has no `file` attribute, because mocha 10.2.0 does not write one);
- with `mocha-core@9.0.0` as a local override: 8 passing, and all 8
  `<testcase>` elements carry `file="server/..."`, including the
  helper-declared suite;
- `meteor test --full-app` still fails as the suite expects (3 failing, exit 1).
